### PR TITLE
`Random` instance for `TestValue`

### DIFF
--- a/src/Test/Tensor.hs
+++ b/src/Test/Tensor.hs
@@ -392,14 +392,13 @@ shrinkElem mZero f tensor = concat [
 
 instance (SNatI n, Arbitrary a, Num a, Eq a) => Arbitrary (Tensor n a) where
   arbitrary = liftArbitrary arbitrary
-
-  shrink = shrinkWith (Just (Zero 0)) shrink
+  shrink    = shrinkWith (Just (Zero 0)) shrink
 
 -- | Lift generators and shrinkers
 --
--- NOTE: Since we cannot put any bounds on the type of the elements here, we
--- cannot use any zero elements. Using 'shrink' (or 'shrinkWith' directly) might
--- result in faster shrinking.
+-- NOTE: Since we cannot put any constraints on the type of the elements here,
+-- we cannot use any zero elements. Using 'shrink' (or 'shrinkWith' directly)
+-- might result in faster shrinking.
 instance SNatI n => Arbitrary1 (Tensor n) where
   liftArbitrary g = QC.sized $ \n -> do
       sz :: Size n <- liftArbitrary $ QC.choose (1, 1 + n)

--- a/src/Test/Tensor/TestValue.hs
+++ b/src/Test/Tensor/TestValue.hs
@@ -42,6 +42,7 @@ instance Eq TestValue where
 -- they are considered to be equal.
 --
 -- > show @TestValue 0     == "0"     -- True zero
+-- > show @TestValue 1     == "1"     -- True one
 -- > show @TestValue 0.001 == "0.00"
 -- > show @TestValue 0.009 == "0.01"
 -- > show @TestValue 1.001 == "1.0"
@@ -49,6 +50,7 @@ instance Eq TestValue where
 instance Show TestValue where
   show (TestValue x)
     | x == 0    = "0"
+    | x == 1    = "1"
     | x <  1    = printf "%0.2f" x
     | x <  10   = printf "%0.1f" x
     | otherwise = printf "%0.0f" x

--- a/src/Test/Tensor/TestValue.hs
+++ b/src/Test/Tensor/TestValue.hs
@@ -6,6 +6,7 @@ module Test.Tensor.TestValue (
   ) where
 
 import Data.List (sort)
+import System.Random (Random)
 import Test.QuickCheck
 import Text.Printf (printf)
 
@@ -18,7 +19,7 @@ import Text.Printf (printf)
 -- Test values are suitable for use in QuickCheck tests involving floating
 -- point numbers, if you want to ignore rounding errors.
 newtype TestValue = TestValue Float
-  deriving newtype (Num, Fractional, Real)
+  deriving newtype (Num, Fractional, Real, Random)
 
 -- | Test values are equipped with a crude equality
 --

--- a/testing-tensor.cabal
+++ b/testing-tensor.cabal
@@ -52,6 +52,7 @@ library
   build-depends:
     , fin          >= 0.3  && < 0.4
     , QuickCheck   >= 2.15 && < 2.16
+    , random       >= 1.2  && < 1.4
     , transformers >= 0.5  && < 0.7
     , vec          >= 0.5  && < 0.6
     , vector       >= 0.13 && < 0.14


### PR DESCRIPTION
#### Tests 

The cuDNN part of the test suite does not run on CI (because we don't have a GPU). Please run these tests yourself prior to submitting the PR (you will need to enable the `test-cudnn` cabal flag).

- [x] I have run the cuDNN tests.
