### PR TITLE
Add `subsWithStride`, release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for tmp
 
+## 0.1.2 -- 2025-08-27
+
+* Add `subsWithStride`
+
 ## 0.1.1 -- 2025-08-27
 
 * Add missing instances for `TestValue`

--- a/src/Test/Tensor.hs
+++ b/src/Test/Tensor.hs
@@ -37,6 +37,7 @@ module Test.Tensor (
   , foreachWith
     -- * Subtensors
   , subs
+  , subsWithStride
   , convolve
   , convolveWithStride
   , padWith
@@ -209,6 +210,12 @@ subs = \kernelSize input ->
         | selected <- consecutive r n (map (go rs ns) xs)
         ]
 
+-- | Generalization of 'subs' allowing for non-default stride
+subsWithStride ::
+     Vec n Int   -- ^ Stride
+  -> Size n -> Tensor n a -> Tensor n (Tensor n a)
+subsWithStride stride sz = applyStride stride . subs sz
+
 -- | Apply stride.
 --
 -- This is the N-dimensional equivalent of 'everyNth'.
@@ -237,7 +244,7 @@ convolveWithStride :: forall n a.
   -> Tensor n a  -- ^ Input
   -> Tensor n a
 convolveWithStride stride kernel input =
-    aux <$> applyStride stride (subs (size kernel) input)
+    aux <$> subsWithStride stride (size kernel) input
   where
     aux :: Tensor n a -> a
     aux = Foldable.foldl' (+) 0 . zipWith (*) kernel

--- a/testing-tensor.cabal
+++ b/testing-tensor.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            testing-tensor
-version:         0.1.1
+version:         0.1.2
 license:         BSD-3-Clause
 license-file:    LICENSE
 author:          Edsko de Vries


### PR DESCRIPTION
#### Tests 

The cuDNN part of the test suite does not run on CI (because we don't have a GPU). Please run these tests yourself prior to submitting the PR (you will need to enable the `test-cudnn` cabal flag).

- [x] I have run the cuDNN tests.
